### PR TITLE
E2E: check for uninstall pod init container successfully completed

### DIFF
--- a/test/e2e/cleanup/submariner.go
+++ b/test/e2e/cleanup/submariner.go
@@ -307,7 +307,8 @@ func (m *podMonitor) assertUninstallPodsCompleted() {
 	Expect(m.pods).ToNot(BeEmpty(), fmt.Sprintf("No uninstall pods were created for component %q", m.name))
 
 	for name, info := range m.pods {
-		if info.status.Phase == corev1.PodRunning {
+		if info.status.InitContainerStatuses[0].State.Terminated != nil &&
+			info.status.InitContainerStatuses[0].State.Terminated.ExitCode == 0 {
 			continue
 		}
 
@@ -318,7 +319,7 @@ func (m *podMonitor) assertUninstallPodsCompleted() {
 			log = info.log
 		}
 
-		Fail(fmt.Sprintf("Pod %q did not complete\nSTATUS: %s\n\nLOG\n: %s\n", name, string(status), log))
+		Fail(fmt.Sprintf("Pod %q did not complete successfully\nSTATUS: %s\n\nLOG\n: %s\n", name, string(status), log))
 	}
 }
 


### PR DESCRIPTION
...instead of pod phase "running" as we've observed sporadic failures where the pod phase is still "pending" even though the init container successfully completed. Also the operator log reported that the associated daemonset was deleted. So uninstall worked correctly. The pod status is cached in the E2E via an informer so it's likely the phase update didn't occur b/c the pod was deleted or it hadn't occurred yet.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
